### PR TITLE
Add preliminary WAMR/WASI target

### DIFF
--- a/build/makefiles/wamr/main.c
+++ b/build/makefiles/wamr/main.c
@@ -1,0 +1,87 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "screen.h"
+#include "xsCommon.h"
+
+extern void fxScreenLaunch(txScreen* screen);
+
+static void fxScreenAbort(txScreen* screen, int status);
+static void fxScreenBufferChanged(txScreen* screen);
+static void fxScreenFormatChanged(txScreen* screen);
+static void fxScreenStart(txScreen* screen, double interval);
+static void fxScreenStop(txScreen* screen);
+
+static txScreen* gxScreen = NULL;
+
+int fxMainIdle(void)
+{
+        if (gxScreen && gxScreen->idle)
+                (*gxScreen->idle)(gxScreen);
+        return 0;
+}
+
+void* fxMainLaunch(int width, int height, void* archive)
+{
+        gxScreen = (txScreen*)malloc(sizeof(txScreen) - 1 + (width * height * screenBytesPerPixel));
+        if (!gxScreen)
+                return NULL;
+        memset(gxScreen, 0, sizeof(txScreen) - 1 + (width * height * screenBytesPerPixel));
+        gxScreen->abort = fxScreenAbort;
+        gxScreen->bufferChanged = fxScreenBufferChanged;
+        gxScreen->formatChanged = fxScreenFormatChanged;
+        gxScreen->start = fxScreenStart;
+        gxScreen->stop = fxScreenStop;
+        gxScreen->width = width;
+        gxScreen->height = height;
+        gxScreen->archive = archive;
+        fxScreenLaunch(gxScreen);
+        return gxScreen->buffer;
+}
+
+int fxMainTouch(int kind, int index, int x, int y, double when)
+{
+        if (gxScreen && gxScreen->touch)
+                (*gxScreen->touch)(gxScreen, kind, index, x, y, when);
+        return 0;
+}
+
+int fxMainQuit(void)
+{
+        if (!gxScreen)
+                return 0;
+        if (gxScreen->quit)
+                (*gxScreen->quit)(gxScreen);
+        if (gxScreen->archive)
+                free(gxScreen->archive);
+        free(gxScreen);
+        gxScreen = NULL;
+        return 0;
+}
+
+static void fxScreenAbort(txScreen* screen, int status)
+{
+        (void)screen;
+        (void)status;
+}
+
+static void fxScreenBufferChanged(txScreen* screen)
+{
+        (void)screen;
+}
+
+static void fxScreenFormatChanged(txScreen* screen)
+{
+        (void)screen;
+}
+
+static void fxScreenStart(txScreen* screen, double interval)
+{
+        (void)screen;
+        (void)interval;
+}
+
+static void fxScreenStop(txScreen* screen)
+{
+        (void)screen;
+}

--- a/tools/mcconfig/make.wamr.mk
+++ b/tools/mcconfig/make.wamr.mk
@@ -1,0 +1,161 @@
+#
+# Copyright (c) 2016-2025  Moddable Tech, Inc.
+#
+#   This file is part of the Moddable SDK Tools.
+#
+#   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   The Moddable SDK Tools is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+WASI_SDK_PATH ?=
+
+ifeq ($(strip $(WASI_SDK_PATH)),)
+CC ?= clang
+AR ?= llvm-ar
+SYSROOT ?=
+else
+CC ?= $(WASI_SDK_PATH)/bin/clang
+AR ?= $(WASI_SDK_PATH)/bin/llvm-ar
+SYSROOT ?= $(WASI_SDK_PATH)/share/wasi-sysroot
+endif
+
+SYSROOT_FLAG := $(if $(strip $(SYSROOT)),--sysroot=$(SYSROOT),)
+TARGET_FLAG := --target=wasm32-wasi
+
+XS_DIRECTORIES = \
+        $(XS_DIR)/includes \
+        $(XS_DIR)/platforms \
+        $(XS_DIR)/sources
+
+XS_HEADERS = \
+        $(XS_DIR)/platforms/wamr_xs.h \
+        $(XS_DIR)/platforms/xsPlatform.h \
+        $(XS_DIR)/includes/xs.h \
+        $(XS_DIR)/includes/xsmc.h \
+        $(XS_DIR)/sources/xsCommon.h \
+        $(XS_DIR)/sources/xsAll.h \
+        $(XS_DIR)/sources/xsScript.h
+
+XS_OBJECTS = \
+        $(LIB_DIR)/wamr_xs.c.o \
+        $(LIB_DIR)/xsAll.c.o \
+        $(LIB_DIR)/xsAPI.c.o \
+        $(LIB_DIR)/xsArguments.c.o \
+        $(LIB_DIR)/xsArray.c.o \
+        $(LIB_DIR)/xsAtomics.c.o \
+        $(LIB_DIR)/xsBigInt.c.o \
+        $(LIB_DIR)/xsBoolean.c.o \
+        $(LIB_DIR)/xsCode.c.o \
+        $(LIB_DIR)/xsCommon.c.o \
+        $(LIB_DIR)/xsDataView.c.o \
+        $(LIB_DIR)/xsDate.c.o \
+        $(LIB_DIR)/xsDebug.c.o \
+        $(LIB_DIR)/xsError.c.o \
+        $(LIB_DIR)/xsFunction.c.o \
+        $(LIB_DIR)/xsGenerator.c.o \
+        $(LIB_DIR)/xsGlobal.c.o \
+        $(LIB_DIR)/xsJSON.c.o \
+        $(LIB_DIR)/xsLexical.c.o \
+        $(LIB_DIR)/xsMapSet.c.o \
+        $(LIB_DIR)/xsMarshall.c.o \
+        $(LIB_DIR)/xsMath.c.o \
+        $(LIB_DIR)/xsMemory.c.o \
+        $(LIB_DIR)/xsModule.c.o \
+        $(LIB_DIR)/xsNumber.c.o \
+        $(LIB_DIR)/xsObject.c.o \
+        $(LIB_DIR)/xsPlatforms.c.o \
+        $(LIB_DIR)/xsPromise.c.o \
+        $(LIB_DIR)/xsProperty.c.o \
+        $(LIB_DIR)/xsProxy.c.o \
+        $(LIB_DIR)/xsRegExp.c.o \
+        $(LIB_DIR)/xsRun.c.o \
+        $(LIB_DIR)/xsScope.c.o \
+        $(LIB_DIR)/xsScript.c.o \
+        $(LIB_DIR)/xsSourceMap.c.o \
+        $(LIB_DIR)/xsString.c.o \
+        $(LIB_DIR)/xsSymbol.c.o \
+        $(LIB_DIR)/xsSyntaxical.c.o \
+        $(LIB_DIR)/xsTree.c.o \
+        $(LIB_DIR)/xsType.c.o \
+        $(LIB_DIR)/xsdtoa.c.o \
+        $(LIB_DIR)/xsmc.c.o \
+        $(LIB_DIR)/xsre.c.o
+
+HEADERS += $(XS_HEADERS)
+
+C_DEFINES = \
+        -DXS_ARCHIVE=1 \
+        -DINCLUDE_XSPLATFORM=1 \
+        -DXSPLATFORM=\"wamr_xs.h\" \
+        -DkCommodettoBitmapFormat=$(COMMODETTOBITMAPFORMAT) \
+        -DkPocoRotation=$(POCOROTATION)
+
+C_INCLUDES += $(DIRECTORIES)
+C_INCLUDES += $(foreach dir,$(XS_DIRECTORIES) $(TMP_DIR),-I$(dir))
+C_INCLUDES += -I$(BUILD_DIR)/simulators/modules
+
+C_FLAGS = -c $(TARGET_FLAG) $(SYSROOT_FLAG) -mexec-model=reactor -D_WASI_EMULATED_PROCESS_CLOCKS
+ifeq ($(DEBUG),)
+        C_FLAGS += -D_RELEASE=1 -O3
+else
+        C_FLAGS += -D_DEBUG=1 -DmxDebug=1 -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
+#       C_FLAGS += -DMC_MEMORY_DEBUG=1
+endif
+
+LINK_OPTIONS = $(TARGET_FLAG) $(SYSROOT_FLAG) -Wl,--no-entry -Wl,--export=fxMainIdle -Wl,--export=fxMainLaunch -Wl,--export=fxMainQuit -Wl,--export=fxMainTouch
+
+LINK_LIBRARIES = -lc -lm
+
+VPATH += $(XS_DIRECTORIES)
+
+.PHONY: all
+
+all: $(LIB_DIR) $(BIN_DIR)/mc.wasm
+build: all
+
+$(LIB_DIR):
+        mkdir -p $(LIB_DIR)
+
+$(BIN_DIR)/mc.wasm: $(XS_OBJECTS) $(TMP_DIR)/mc.xs.c.o $(TMP_DIR)/mc.resources.c.o $(OBJECTS) $(TMP_DIR)/mc.main.c.o
+        @echo "# ld mc.wasm"
+        $(CC) $(LINK_OPTIONS) $^ $(LINK_LIBRARIES) -o $@
+
+$(XS_OBJECTS) : $(XS_HEADERS)
+$(LIB_DIR)/%.c.o: %.c
+        @echo "# cc" $(<F)
+        $(CC) $(C_DEFINES) $(C_INCLUDES) $(C_FLAGS) $< -o $@
+
+$(TMP_DIR)/mc.xs.c.o: $(TMP_DIR)/mc.xs.c $(HEADERS)
+        @echo "# cc" $(<F)
+        $(CC) $(C_DEFINES) $(C_INCLUDES) $(C_FLAGS) $< -o $@
+
+$(TMP_DIR)/mc.xs.c: $(MODULES) $(MANIFEST)
+        @echo "# xsl modules"
+        xsl -b $(MODULES_DIR) -o $(TMP_DIR) $(PRELOADS) $(STRIPS) $(CREATION) $(MODULES)
+
+$(TMP_DIR)/mc.resources.c.o: $(TMP_DIR)/mc.resources.c $(HEADERS)
+        @echo "# cc" $(<F)
+        $(CC) $(C_DEFINES) $(C_INCLUDES) $(C_FLAGS) $< -o $@
+
+$(TMP_DIR)/mc.resources.c: $(DATA) $(RESOURCES) $(MANIFEST)
+        @echo "# mcrez resources"
+        mcrez $(DATA) $(RESOURCES) -o $(TMP_DIR) -r mc.resources.c
+
+$(TMP_DIR)/mc.main.c.o: $(BUILD_DIR)/makefiles/wamr/main.c $(HEADERS)
+        @echo "# cc" $(<F)
+        $(CC) $(C_DEFINES) $(C_INCLUDES) $(C_FLAGS) $< -o $@
+
+MAKEFLAGS += --jobs
+ifneq ($(VERBOSE),1)
+MAKEFLAGS += --silent
+endif

--- a/xs/platforms/wamr_xs.c
+++ b/xs/platforms/wamr_xs.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016-2017  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *       Copyright (C) 2010-2016 Marvell International Ltd.
+ *       Copyright (C) 2002-2010 Kinoma, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ */
+
+#include "xsAll.h"
+#include "xsScript.h"
+
+void fxCreateMachinePlatform(txMachine* the)
+{
+}
+
+void fxDeleteMachinePlatform(txMachine* the)
+{
+}
+
+void fxQueuePromiseJobs(txMachine* the)
+{
+}
+
+#ifdef mxDebug
+
+void fxConnect(txMachine* the)
+{
+}
+
+void fxDisconnect(txMachine* the)
+{
+}
+
+txBoolean fxIsConnected(txMachine* the)
+{
+        return 0;
+}
+
+txBoolean fxIsReadable(txMachine* the)
+{
+        return 0;
+}
+
+void fxReceive(txMachine* the)
+{
+}
+
+void fxSend(txMachine* the, txBoolean more)
+{
+}
+#endif

--- a/xs/platforms/wamr_xs.h
+++ b/xs/platforms/wamr_xs.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016-2017  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *       Copyright (C) 2010-2016 Marvell International Ltd.
+ *       Copyright (C) 2002-2010 Kinoma, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ */
+
+#ifndef __WAMR_XS__
+#define __WAMR_XS__
+
+#undef mxWasm
+#define mxWasm 1
+
+#include <ctype.h>
+#include <float.h>
+#include <math.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <errno.h>
+
+#define mxUseDefaultBuildKeys 1
+#define mxUseDefaultChunkAllocation 1
+#define mxUseDefaultSlotAllocation 1
+#define mxUseDefaultFindModule 1
+#define mxUseDefaultLoadModule 1
+#define mxUseDefaultParseScript 1
+#define mxUseDefaultSharedChunks 1
+
+#define mxMachinePlatform \
+        void* host;
+
+#endif /* __WAMR_XS__ */


### PR DESCRIPTION
## Summary
- add WAMR/WASI XS platform scaffolding
- provide mcconfig makefile to build wasm32-wasi artifacts with clang or wasi-sdk
- add a minimal launcher implementation for WAMR builds

## Testing
- not run (toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf69758f348322a6f9519b6cba01dc