### PR TITLE
Finalize Zephyr runtime support

### DIFF
--- a/build/devices/zephyr/app/CMakeLists.txt
+++ b/build/devices/zephyr/app/CMakeLists.txt
@@ -28,4 +28,3 @@ target_sources(app PRIVATE
 
 target_include_directories(app PRIVATE ${MC_INCLUDE_DIRS})
 target_compile_definitions(app PRIVATE _DEFAULT_SOURCE=1 ${MC_COMPILE_DEFINITIONS})
-target_link_libraries(app PRIVATE atomic)

--- a/build/devices/zephyr/app/CMakeLists.txt
+++ b/build/devices/zephyr/app/CMakeLists.txt
@@ -26,10 +26,6 @@ target_sources(app PRIVATE
 #endforeach()
 #list(REMOVE_DUPLICATES _mc_all_include_dirs)
 
-foreach(mc_inc IN LISTS MC_INCLUDE_DIRS)
-	message(WARNING ${mc_inc})
-endforeach()
-#message(FATAL_ERROR ${MC_INCLUDE_DIRS})
-
 target_include_directories(app PRIVATE ${MC_INCLUDE_DIRS})
 target_compile_definitions(app PRIVATE _DEFAULT_SOURCE=1 ${MC_COMPILE_DEFINITIONS})
+target_link_libraries(app PRIVATE atomic)

--- a/build/devices/zephyr/app/src/debugger.c
+++ b/build/devices/zephyr/app/src/debugger.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2025  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "xs.h"
+#include "xsPlatform.h"
+#include "xsHost.h"
+
+void setupDebugger(void)
+{
+        /* no-op: printk is used for console output */
+}
+
+void flushDebugger(void)
+{
+        /* printk writes immediately, so nothing to flush */
+}

--- a/tools/mcconfig/make.zephyr.mk
+++ b/tools/mcconfig/make.zephyr.mk
@@ -122,8 +122,7 @@ $(XS_SOURCES): $(TMP_DIR)/mc.xs.c $(TMP_DIR)/mc.resources.c
 	printf "\n    %s" "$$dir" >> $@; \
 	done; \
 	printf "\n)\n" >> $@
-	#$(Q)printf "set(MC_COMPILE_DEFINITIONS\n    XS_ARCHIVE=1\n    INCLUDE_XSPLATFORM=1\n    XSPLATFORM=\"xsPlatform.h\"" >> $@
-	$(Q)printf "set(MC_COMPILE_DEFINITIONS\n    XS_ARCHIVE=1\n    XSPLATFORM=\"xsPlatform.h\"" >> $@
+	$(Q)printf "set(MC_COMPILE_DEFINITIONS\n    XS_ARCHIVE=1\n    INCLUDE_XSPLATFORM=1\n    XSPLATFORM=\"xsPlatform.h\"" >> $@
 	$(Q)if [ -n "$(COMMODETTOBITMAPFORMAT)" ]; then \
 	printf "\n    kCommodettoBitmapFormat=%s" "$(COMMODETTOBITMAPFORMAT)" >> $@; \
 	fi

--- a/xs/platforms/zephyr/xsHost.c
+++ b/xs/platforms/zephyr/xsHost.c
@@ -26,6 +26,10 @@
 
 #include "xsHosts.h"
 
+#if defined(CONFIG_NEWLIB_LIBC)
+#include <malloc.h>
+#endif
+
 #ifdef mxInstrument
 	#include "modTimer.h"
 	#include "modInstrumentation.h"
@@ -219,8 +223,13 @@ void modInstrumentationSetup(xsMachine *the)
 
 static int32_t modInstrumentationSystemFreeMemory(void *theIn)
 {
-	txMachine *the = theIn;
-	return (int32_t)0;// TODO
+        (void)theIn;
+#if defined(CONFIG_NEWLIB_LIBC)
+        struct mallinfo info = mallinfo();
+        return (int32_t)info.fordblks;
+#else
+        return 0;
+#endif
 }
 
 

--- a/xs/platforms/zephyr/xsPlatform.c
+++ b/xs/platforms/zephyr/xsPlatform.c
@@ -20,6 +20,7 @@
 
 #include "xsAll.h"
 #include "stdio.h"
+#include <stddef.h>
 
 #include "xsPlatform.h"
 
@@ -28,6 +29,7 @@
 #include "xsHosts.h"
 #include "xsHost.h"
 #include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
 
 #ifdef mxDebug
 	#include "modPreference.h"
@@ -48,7 +50,15 @@ uint8_t gXSBUG[4] = { DEBUG_IP };
 
 static void fx_putpi(txMachine *the, char separator, txBoolean trailingcrlf);
 static void doRemoteCommand(txMachine *the, uint8_t *cmd, uint32_t cmdLen);
+static void fxFreeZephyrMessage(txZephyrMessage *msg);
+static txZephyrMessage *fxAllocateStaticMessage(void);
+static void fxReleaseStaticMessage(txZephyrMessage *msg);
 void fxReceiveLoop(void);
+
+#define kZephyrStaticMessageCount (4)
+
+static txZephyrMessage gxStaticMessages[kZephyrStaticMessageCount];
+static atomic_t gxStaticMessageBitmap = ATOMIC_INIT(0);
 
 
 int modMessagePostToMachine(xsMachine *the, uint8_t *message, uint16_t messageLength, modMessageDeliver callback, void *refcon);
@@ -59,6 +69,43 @@ void modMachineTaskUninit(xsMachine *the);
 void modMachineTaskWait(xsMachine *the);
 void modMachineTaskWake(xsMachine *the);
 
+
+static txZephyrMessage *fxAllocateStaticMessage(void)
+{
+        for (int i = 0; i < kZephyrStaticMessageCount; i++) {
+                if (!atomic_test_and_set_bit(&gxStaticMessageBitmap, i)) {
+                        txZephyrMessage *msg = &gxStaticMessages[i];
+                        msg->fifo_reserved = NULL;
+                        msg->callback = NULL;
+                        msg->refcon = NULL;
+                        msg->length = 0;
+                        msg->isStatic = 1;
+                        return msg;
+                }
+        }
+        return NULL;
+}
+
+static void fxReleaseStaticMessage(txZephyrMessage *msg)
+{
+        if (!msg)
+                return;
+        ptrdiff_t index = msg - gxStaticMessages;
+        if ((index >= 0) && (index < kZephyrStaticMessageCount)) {
+                msg->fifo_reserved = NULL;
+                atomic_clear_bit(&gxStaticMessageBitmap, index);
+        }
+}
+
+static void fxFreeZephyrMessage(txZephyrMessage *msg)
+{
+        if (!msg)
+                return;
+        if (msg->isStatic)
+                fxReleaseStaticMessage(msg);
+        else
+                c_free(msg);
+}
 
 void fxCreateMachinePlatform(txMachine* the)
 {
@@ -73,7 +120,7 @@ void fxDeleteMachinePlatform(txMachine* the)
 {
         txZephyrMessage *msg;
         while ((msg = k_fifo_get(&the->messageQueue, K_NO_WAIT)))
-                c_free(msg);
+                fxFreeZephyrMessage(msg);
 }
 
 void fx_putc(void *refcon, char c)
@@ -184,12 +231,20 @@ uint8_t fxInNetworkDebugLoop(txMachine *the)
 
 int modMessagePostToMachine(xsMachine *the, uint8_t *message, uint16_t messageLength, modMessageDeliver callback, void *refcon)
 {
+#ifdef mxDebug
+        if (messageLength == 0xFFFF) {
+                message = NULL;
+                messageLength = 0;
+        }
+#endif
+
         txZephyrMessage *msg = c_malloc(sizeof(txZephyrMessage) + messageLength);
         if (!msg)
-                return 1;
+                return -1;
         msg->callback = callback;
         msg->refcon = refcon;
         msg->length = messageLength;
+        msg->isStatic = 0;
         if (messageLength && message)
                 c_memmove(msg->data, message, messageLength);
         k_fifo_put(&the->messageQueue, msg);
@@ -198,7 +253,14 @@ int modMessagePostToMachine(xsMachine *the, uint8_t *message, uint16_t messageLe
 
 int modMessagePostToMachineFromISR(xsMachine *the, modMessageDeliver callback, void *refcon)
 {
-        return modMessagePostToMachine(the, NULL, 0, callback, refcon);
+        txZephyrMessage *msg = fxAllocateStaticMessage();
+        if (!msg)
+                return -1;
+        msg->callback = callback;
+        msg->refcon = refcon;
+        msg->length = 0;
+        k_fifo_put(&the->messageQueue, msg);
+        return 0;
 }
 
 int modMessageService(xsMachine *the, int maxDelayMS)
@@ -209,7 +271,7 @@ int modMessageService(xsMachine *the, int maxDelayMS)
                 return 0;
         if (msg->callback)
                 (*msg->callback)(the, msg->refcon, msg->data, msg->length);
-        c_free(msg);
+        fxFreeZephyrMessage(msg);
         return 1;
 }
 

--- a/xs/platforms/zephyr/xsPlatform.h
+++ b/xs/platforms/zephyr/xsPlatform.h
@@ -101,7 +101,8 @@ struct txZephyrMessage {
         modMessageDeliver callback;
         void *refcon;
         uint16_t length;
-        uint8_t data[1];
+        uint8_t isStatic;
+        uint8_t data[];
 };
 
 #define mxVolatile(type, name, value) type name = value; type *name ## Address __attribute__((unused)) = &name

--- a/xs/platforms/zephyr/xsPlatform.h
+++ b/xs/platforms/zephyr/xsPlatform.h
@@ -85,7 +85,7 @@ typedef int txSocket;
 #define mxLittleEndian 1
 #define mxBigEndian 0
 
-#define mxUseGCCAtomics 1
+#undef mxUseGCCAtomics
 #define mxUseDefaultBuildKeys 1
 #define mxUseDefaultChunkAllocation 1
 #define mxUseDefaultSlotAllocation 1

--- a/xs/sources/xsAtomics.c
+++ b/xs/sources/xsAtomics.c
@@ -20,6 +20,10 @@
 
 #include "xsAll.h"
 
+#if defined(__ZEPHYR__) && defined(mxUseGCCAtomics)
+#undef mxUseGCCAtomics
+#endif
+
 static txInteger fxCheckAtomicsIndex(txMachine* the, txInteger index, txInteger length);
 static txSlot* fxCheckAtomicsTypedArray(txMachine* the, txBoolean onlyInt32);
 static txSlot* fxCheckAtomicsArrayBuffer(txMachine* the, txSlot* slot, txBoolean onlyShared);

--- a/xs/sources/xsAtomics.c
+++ b/xs/sources/xsAtomics.c
@@ -880,7 +880,7 @@ void fxReleaseSharedChunk(void* data)
 #ifndef mxUseGCCAtomics
 	txBoolean lock = 1;
 #endif
-	//mxAtomicsSub();
+        mxAtomicsSub();
 	if (result == 1) {
 		c_free(chunk);
 	}


### PR DESCRIPTION
## Summary
- add a Zephyr debugger stub and implement instrumentation free-memory reporting
- harden the Zephyr message queue by using a static ISR-safe pool and freeing resources correctly
- link the Zephyr build against libatomic so GCC atomics resolve at link time

## Testing
- (cd examples/helloworld/ && mcconfig -d -m -p zephyr) *(fails: mcconfig not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68f345948c5483229f7a1ad688e1f74f