### PR TITLE
Add WAMR run target and usage docs

### DIFF
--- a/documentation/devices/wasm.md
+++ b/documentation/devices/wasm.md
@@ -111,12 +111,12 @@ This document provides instructions to build and run Moddable SDK apps for the W
 
 	If you are using Python 3:
 
-	```text
-	cd $MODDABLE/build/bin/wasm/debug/balls
-	python3 -m http.server
-	```
+        ```text
+        cd $MODDABLE/build/bin/wasm/debug/balls
+        python3 -m http.server
+        ```
 
-	Go to [`localhost:8000`](http://localhost:8000) in a browser. You should see a web page with a simulator running `balls`.
+        Go to [`localhost:8000`](http://localhost:8000) in a browser. You should see a web page with a simulator running `balls`.
 
 <a id="lin"></a>
 ## Linux
@@ -215,9 +215,19 @@ This document provides instructions to build and run Moddable SDK apps for the W
 	```text
 	cd $MODDABLE/build/bin/wasm/debug/balls
 	python3 -m http.server
-	```
+        ```
 
-	Go to [`localhost:8000`](http://localhost:8000) in a browser. You should see a web page with a simulator running `balls`.
+        Go to [`localhost:8000`](http://localhost:8000) in a browser. You should see a web page with a simulator running `balls`.
+
+## Running WAMR builds
+
+The Moddable SDK can also target the [WebAssembly Micro Runtime (WAMR)](https://github.com/bytecodealliance/wasm-micro-runtime) for headless execution. After building an app for WAMR, you can run it directly from `mcconfig` by requesting the new `run` target:
+
+```
+mcconfig -d -m -p wamr -t run
+```
+
+By default the `run` target executes `iwasm` with the generated `mc.wasm` binary from the build output directory. If you need to use a different runtime binary or pass additional flags, set the `WAMR_RUNTIME` and `WAMR_RUNTIME_FLAGS` environment variables before invoking `mcconfig`.
 
 <a id="limitations"></a>
 ## Limitations

--- a/tools/mcconfig/make.wamr.mk
+++ b/tools/mcconfig/make.wamr.mk
@@ -124,10 +124,18 @@ LINK_LIBRARIES = -lc -lsetjmp -lm
 
 VPATH += $(XS_DIRECTORIES)
 
-.PHONY: all	
-	
-all: $(LIB_DIR) $(BIN_DIR)/mc.wasm
-build: all
+.PHONY: all build run
+
+WAMR_RUNTIME ?= iwasm
+WAMR_RUNTIME_FLAGS ?=
+
+all: run
+
+build: $(LIB_DIR) $(BIN_DIR)/mc.wasm
+
+run: build
+	@echo "# run mc.wasm"
+	$(WAMR_RUNTIME) $(WAMR_RUNTIME_FLAGS) $(BIN_DIR)/mc.wasm
 
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)


### PR DESCRIPTION
## Summary
- add a dedicated run target to the WAMR make fragment so mcconfig can execute mc.wasm through the runtime
- document how to launch WAMR builds via mcconfig and customize the runtime command

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f40dee0a2883229ec3927cea8695cd