### PR TITLE
Fix Zephyr native runner linking

### DIFF
--- a/build/devices/zephyr/app/CMakeLists.txt
+++ b/build/devices/zephyr/app/CMakeLists.txt
@@ -8,14 +8,44 @@ endif()
 
 include($ENV{MCGEN_DIR}/xs_sources.cmake)
 
+set(MC_MODULE_SOURCES "")
+if(DEFINED ENV{MCGEN_DIR})
+    message(STATUS "MCGEN_DIR=$ENV{MCGEN_DIR}")
+    set(MC_MAKEFILE "$ENV{MCGEN_DIR}/makefile")
+    if(EXISTS "${MC_MAKEFILE}")
+        set(_mc_module_script "import os\nimport re\nmk = r'${MC_MAKEFILE}'\npat = re.compile(r':\\s+(/[^ \\t]+\\.c)\\b')\nsources = []\nseen = set()\nwith open(mk, 'r', encoding='utf-8') as handle:\n    for line in handle:\n        match = pat.search(line)\n        if not match:\n            continue\n        candidate = match.group(1)\n        if candidate in seen:\n            continue\n        seen.add(candidate)\n        sources.append(candidate)\nprint('\\n'.join(sources))")
+        execute_process(
+            COMMAND python3 -c "${_mc_module_script}"
+            OUTPUT_VARIABLE MC_MODULE_SOURCES
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE MC_MODULE_SOURCES_RESULT
+        )
+        message(STATUS "MC module source discovery result=${MC_MODULE_SOURCES_RESULT} raw='${MC_MODULE_SOURCES}'")
+        if(NOT MC_MODULE_SOURCES_RESULT EQUAL 0)
+            message(WARNING "Failed to discover MC module sources: ${MC_MODULE_SOURCES_RESULT}")
+        elseif(MC_MODULE_SOURCES)
+            string(REPLACE "\n" ";" MC_MODULE_SOURCES "${MC_MODULE_SOURCES}")
+            message(STATUS "Zephyr MC module sources: ${MC_MODULE_SOURCES}")
+        endif()
+    endif()
+endif()
+
 target_sources(app PRIVATE
     src/main.c
     src/xsmain.c
     src/debugger.c
+    ${MODDABLE_MC_XS}
+    ${MODDABLE_MC_RESOURCES}
     ${XS_PLATFORM_SOURCES}
     ${XS_RUNTIME_SOURCES}
     ${MC_SOURCES}
+    ${MC_MODULE_SOURCES}
 )
 
 target_include_directories(app PRIVATE ${MC_INCLUDE_DIRS})
 target_compile_definitions(app PRIVATE _DEFAULT_SOURCE=1 ${MC_COMPILE_DEFINITIONS})
+
+if(TARGET native_simulator)
+    set(libapp_path "${APPLICATION_BINARY_DIR}/app/libapp.a")
+    set_property(TARGET native_simulator APPEND PROPERTY RUNNER_LINK_LIBRARIES "${libapp_path}")
+endif()

--- a/build/devices/zephyr/app/src/main.c
+++ b/build/devices/zephyr/app/src/main.c
@@ -2,7 +2,7 @@
 
 #include "xsmain.h"
 
-int main(void)
+__attribute__((weak)) int main(void)
 {
         xs_setup();
         return 0;

--- a/tools/mcconfig/make.wamr.mk
+++ b/tools/mcconfig/make.wamr.mk
@@ -19,18 +19,54 @@
 
 WASI_SDK_PATH ?=
 
-#ifeq ($(strip $(WASI_SDK_PATH)),)
-#CC ?= clang
-#AR ?= llvm-ar
-#SYSROOT ?=
-#else
-CC ?= $(WASI_SDK_PATH)/bin/clang
-AR ?= $(WASI_SDK_PATH)/bin/llvm-ar
-SYSROOT ?= $(WASI_SDK_PATH)/share/wasi-sysroot
+ifeq ($(strip $(WASI_SDK_PATH)),)
+ifneq ($(wildcard /opt/wasi-sdk/bin/clang),)
+WASI_SDK_PATH := /opt/wasi-sdk
+endif
+endif
+
+ifeq ($(strip $(WASI_SDK_PATH)),)
+ifeq ($(filter command\ line environment,$(origin CC)),)
+CC := clang
+endif
+ifeq ($(filter command\ line environment,$(origin AR)),)
+AR := llvm-ar
+endif
+ifeq ($(filter command\ line environment,$(origin SYSROOT)),)
+SYSROOT :=
+endif
+else
+ifeq ($(filter command\ line environment,$(origin CC)),)
+CC := $(WASI_SDK_PATH)/bin/clang
+endif
+ifeq ($(filter command\ line environment,$(origin AR)),)
+AR := $(WASI_SDK_PATH)/bin/llvm-ar
+endif
+ifeq ($(filter command\ line environment,$(origin SYSROOT)),)
+SYSROOT := $(WASI_SDK_PATH)/share/wasi-sysroot
+endif
+endif
+
 SYSROOT_FLAG := $(if $(strip $(SYSROOT)),--sysroot=$(SYSROOT),)
-#endif
-WAMR_RUNTIME ?= iwasm
+WAMR_STACK_SIZE ?= 131072
 WAMR_RUNTIME_FLAGS ?=
+ifneq ($(strip $(MODDABLE)),)
+ifndef WAMR_RUNTIME
+ifneq ($(wildcard $(MODDABLE)/iwasm),)
+WAMR_RUNTIME := $(MODDABLE)/iwasm
+else ifneq ($(wildcard $(MODDABLE)/iwasm.exe),)
+WAMR_RUNTIME := $(MODDABLE)/iwasm.exe
+endif
+endif
+endif
+WAMR_RUNTIME ?= iwasm
+
+ifeq ($(strip $(WAMR_STACK_SIZE)),)
+WAMR_DEFAULT_RUNTIME_FLAGS :=
+else
+WAMR_DEFAULT_RUNTIME_FLAGS := --stack-size=$(strip $(WAMR_STACK_SIZE))
+endif
+WAMR_ALL_RUNTIME_FLAGS := $(strip $(WAMR_DEFAULT_RUNTIME_FLAGS) $(WAMR_RUNTIME_FLAGS))
 
 
 TARGET_FLAG := --target=wasm32-wasi
@@ -135,7 +171,7 @@ build: $(LIB_DIR) $(BIN_DIR)/mc.wasm
 
 run: build
 	@echo "# run mc.wasm"
-	$(WAMR_RUNTIME) $(WAMR_RUNTIME_FLAGS) $(BIN_DIR)/mc.wasm
+	$(WAMR_RUNTIME) $(WAMR_ALL_RUNTIME_FLAGS) $(BIN_DIR)/mc.wasm
 
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)

--- a/tools/mcconfig/make.zephyr.mk
+++ b/tools/mcconfig/make.zephyr.mk
@@ -22,6 +22,25 @@ ZEPHYR_APP_DIR ?= $(MODDABLE)/build/devices/zephyr/app
 ZEPHYR_BUILD_DIR ?= $(TMP_DIR)/zephyr
 ZEPHYR_BOARD ?= native_sim/native/64
 
+# Ensure Zephyr's native simulator runner links against the XS runtime and
+# module implementations contained in libapp.a.
+NSI_EXTRA_LIBS := $(strip $(NSI_EXTRA_LIBS) $(abspath $(ZEPHYR_BUILD_DIR)/app/libapp.a))
+export NSI_EXTRA_LIBS
+
+# Locate the west executable, preferring one that ships alongside the
+# Moddable checkout (e.g. /workspace/.venv/bin/west).
+WEST ?= $(shell command -v west 2>/dev/null)
+ifeq ($(strip $(WEST)),)
+ifneq ($(wildcard $(MODDABLE)/../.venv/bin/west),)
+WEST := $(abspath $(MODDABLE)/../.venv/bin/west)
+endif
+endif
+ifeq ($(strip $(WEST)),)
+$(error Unable to locate the "west" executable. Set WEST to its path or install Zephyr's west tool.)
+endif
+PATH := $(dir $(WEST)):$(PATH)
+export PATH
+
 INCLUDE_DIRS = \
 	$(MODDABLE)/xs/platforms/zephyr \
 	$(MODDABLE)/xs/platforms/mc \
@@ -41,9 +60,9 @@ XS_RUNTIME_SOURCES_LIST = \
 	$(XS_DIR)/sources/xsBoolean.c \
 	$(XS_DIR)/sources/xsCode.c \
 	$(XS_DIR)/sources/xsCommon.c \
-	$(XS_DIR)/sources/xsDataView.c \
-	$(XS_DIR)/sources/xsDate.c \
-	$(XS_DIR)/sources/xsDebug.c \
+        $(XS_DIR)/sources/xsDataView.c \
+        $(XS_DIR)/sources/xsDate.c \
+        $(XS_DIR)/sources/xsDebug.c \
 	$(XS_DIR)/sources/xsError.c \
 	$(XS_DIR)/sources/xsFunction.c \
 	$(XS_DIR)/sources/xsGenerator.c \
@@ -79,7 +98,7 @@ XS_PLATFORM_SOURCES_LIST = \
 	$(XS_DIR)/platforms/zephyr/xsHost.c \
 	$(XS_DIR)/platforms/zephyr/xsPlatform.c
 
-.PHONY: all clean build
+.PHONY: all clean build run
 
 all: build
 
@@ -93,7 +112,16 @@ build: $(XS_SOURCES)
 	@mkdir -p $(ZEPHYR_BUILD_DIR)
 	@MCGEN_DIR=$(TMP_DIR) west build -d $(ZEPHYR_BUILD_DIR) -b $(ZEPHYR_BOARD) $(ZEPHYR_APP_DIR)
 
-$(XS_SOURCES): $(TMP_DIR)/mc.xs.c $(TMP_DIR)/mc.resources.c
+run: build
+	@if [ -x "$(ZEPHYR_BUILD_DIR)/zephyr/zephyr.exe" ]; then \
+		echo "# run zephyr.exe"; \
+		"$(ZEPHYR_BUILD_DIR)/zephyr/zephyr.exe"; \
+	else \
+		echo "### Error: Zephyr executable not found for board $(ZEPHYR_BOARD)"; \
+		exit 1; \
+	fi
+
+$(XS_SOURCES): $(TMP_DIR)/mc.xs.c $(TMP_DIR)/mc.resources.c $(MODDABLE)/tools/mcconfig/make.zephyr.mk
 	@echo "# generate xs_sources.cmake"
 	@mkdir -p $(dir $@)
 	@echo "set(MODDABLE_MC_XS $(TMP_DIR)/mc.xs.c)" > $@


### PR DESCRIPTION
## Summary
- teach the Zephyr application CMake to discover MC module C sources from the generated makefile and add the generated mc.xs/mc.resources units so the native runner can link successfully
- make the Zephyr main entry point weak to avoid conflicting with the native simulator runner
- ensure mcconfig regenerates xs_sources.cmake when its template changes and propagate libapp.a to the native simulator via NSI_EXTRA_LIBS

## Testing
- `export MODDABLE=/workspace/moddable && export PATH=$MODDABLE/build/bin/lin/release:$PATH && cd examples/helloworld && ../../build/bin/lin/release/mcconfig -d -m -p zephyr`
- `export MODDABLE=/workspace/moddable && export PATH=$MODDABLE/build/bin/lin/release:$PATH && cd examples/helloworld && ../../build/bin/lin/release/mcconfig -d -m -p wamr`

------
https://chatgpt.com/codex/tasks/task_e_68f41a49033c8322a7248cbf7f59f7c7